### PR TITLE
fix Yarra being slightly lower than other chars

### DIFF
--- a/Bust Config.rb
+++ b/Bust Config.rb
@@ -966,6 +966,7 @@ Busty::MESSAGE_CONFIG.merge!({
   },
   "Yarra" => {
     bust_offset_x: -55,
+    bust_offset_y: 10,
   },
   "Dari1" => {
     bust_offset_x: -30,


### PR DESCRIPTION
This is in response to Innocuous' latest post on the below thread - I've checked Lynine and Elleani and they're fine, but Yarra was indeed a little low.
https://www.patreon.com/posts/tls-0-75-3-112013132